### PR TITLE
Fix for KZ IBAN numbers validation

### DIFF
--- a/lib/iban-tools/rules.yml
+++ b/lib/iban-tools/rules.yml
@@ -158,7 +158,7 @@
 'KZ':
   # Kazakhstan
   length: 20
-  bban_pattern: '\d{3}[A-Z]{3}\d{10}'
+  bban_pattern: '[0-9]{3}[A-Z0-9]{13}'
 
 'LB':
   # Lebanon


### PR DESCRIPTION
The previous pattern was too restrictive and rejected valid IBANs. 
