### PR TITLE
Ukrainian IBAN fails to pass validation

### DIFF
--- a/lib/iban-tools/rules.yml
+++ b/lib/iban-tools/rules.yml
@@ -280,3 +280,7 @@
   length: 26
   bban_pattern: '\d{5}[A-Z0-9]{17}'
 
+'UA':
+  # Ukraine
+  length: 29
+  bban_pattern: '\d{25}'


### PR DESCRIPTION
http://en.wikipedia.org/wiki/International_Bank_Account_Number

http://www.nordea.com/Our+services/Cash+Management/Products+and+services/IBAN+countries/908462.html
Ukraine	29 an	UA573543470006762462054925026

Passes validation at http://www.iban.net/